### PR TITLE
Crop maintaining aspect ratio of image.

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,23 +159,25 @@ module.exports = function(options = {}) {
         // If height is more we'll trim the width
         if (height_aspect < width_aspect) {
 
-          // Position it in the centre to crop the width.
-          var adjust = ( image.bitmap.width / height_aspect ) - width;
+          // Resize the width based on the height_aspect.
+          var adjust = image.bitmap.width / height_aspect;
 
           image
             .resize(adjust, height)
-            .crop( adjust / 2 , 0, width, height)
+            // Centre the image so we can crop to required height.
+            .crop( ( adjust - width ) / 2 , 0, width, height)
             .quality(options.quality);
 
         } else {
           // Else we'll trim the height
 
-          // Position it in the centre to crop the height.
-          var adjust = ( image.bitmap.height / width_aspect ) - height;
+          // Resize the height based on the width_aspect.
+          var adjust = image.bitmap.height / width_aspect;
 
           image
             .resize(width, adjust)
-            .crop(0, adjust / 2 , width, height)
+            // Centre the image so we can crop to required width.
+            .crop(0, ( adjust - height ) / 2 , width, height)
             .quality(options.quality);
 
         }

--- a/index.js
+++ b/index.js
@@ -123,11 +123,16 @@ module.exports = function(options = {}) {
           width = Jimp.AUTO;
         }
       } else {
+        var
+          width_aspect = false,
+          height_aspect = false
         if (
           typeof width === "string" &&
           width.substr(width.length - 1) === "%"
         ) {
           width = Math.round(image.bitmap.width * (parseFloat(width) / 100))
+        } else {
+          width_aspect = image.bitmap.width / width;
         }
 
         if (
@@ -135,10 +140,22 @@ module.exports = function(options = {}) {
           height.substr(height.length - 1) === "%"
         ) {
           height = Math.round(image.bitmap.height * (parseFloat(height) / 100))
+        } else {
+          height_aspect = image.bitmap.height / height;
         }
       }
 
-      image.resize(width, height).quality(options.quality);
+      if (height_aspect && width_aspect && height_aspect != width_aspect) {
+        if (height_aspect < width_aspect) {
+          var adjust = image.bitmap.width / height_aspect;
+          image.resize(adjust, height).crop( (adjust - width) / 2 , 0, width, height).quality(options.quality);
+        } else {
+          var adjust = image.bitmap.height / width_aspect;
+          image.resize(width, adjust).crop(0, (adjust - height) / 2 , width, height).quality(options.quality);
+        }
+      } else {
+        image.resize(width, height).quality(options.quality);
+      }
 
       image.getBuffer(format, (err, buffer) => {
         if (err) {


### PR DESCRIPTION
I could have been using this wrong but I found when specifying width and height it would squash my images, I couldn't find any thing to maintain my images without that squish.
Due to this I added a simple bit of code to scale image to requested width/height and crop overlap (keeping it central).

Problem that I haven't been able to fix is it will not allow you to set width and no height & vice versa.
If I figure that out I'll do another pull request but I figured its worth putting out their someone else may spot my mistake faster.