### PR TITLE
Feature: verbose logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ gulp.task('resize', function() {
 
 # Available options
 
+* `verbose` - log file processing options, each image as processed. Default: **false**
 * `format` - fromat of output files (png, jpg, gif, bmp or *). Default: *
 * `width` - width of output images (fixed, percentage or -1 for auto). Default: **-1**
 * `height` - height of output images (fixed, percentage or -1 for auto). Default: **-1**

--- a/index.js
+++ b/index.js
@@ -76,6 +76,10 @@ module.exports = function(options = {}) {
   options.tinify = options.tinify || false;
   options.tinifyKey = options.tinifyKey || "";
 
+  if (options.verbose) {
+    console.log("gulp-images-resizer starting with options ", JSON.stringify(options));
+  }
+
   function bufferContents(file, enc, cb) {
     if (file.isNull()) {
       cb();
@@ -96,6 +100,10 @@ module.exports = function(options = {}) {
     }
 
     Jimp.read(file.contents, (err, image) => {
+      if (options.verbose) {
+        console.log("Processing image", file.relative);
+      }
+
       if (err) {
         console.error(getErrorDescription("Error reading " + file.relative));
         cb();


### PR DESCRIPTION
Useful sometimes to get output like:

```bash
[12:37:31] Starting 'images'...
gulp-images-resizer starting with options  {"verbose":true,"format":"png","width":900,"height":600,"noCrop":false,"quality":100,"tinify":false,"tinifyKey":""}
Processing image blog/13903560833_970f66b3c2_k.jpg
Processing image blog/cam-model-ontology.jpg
Processing image blog/cam-model-terraced-farming.jpg
Processing image blog/corridor.jpg
Processing image blog/doors.jpg
Processing image blog/drill-bits.jpg
Processing image blog/ethernet.jpg
Processing image blog/euro-ia.jpg
Processing image blog/mail-pile.jpg
Processing image blog/newspapers.jpg
Processing image blog/panini.jpg
...
```

Used like

```js
  // Cinematic crop
  gulp.src('./images/**/*{.jpg,.png,.gif}')
    .pipe(resizer({
      verbose: true,
      format: "png",
      width: 900,
      height: 600
    }))
    .pipe(gulp.dest('build/images/crop-cinema/'))
    .on('end', done);
```